### PR TITLE
l4p/tcp: Add ability to adjust/offset tcp timestamps when proxying

### DIFF
--- a/lib/libtle_l4p/tcp_misc.h
+++ b/lib/libtle_l4p/tcp_misc.h
@@ -213,10 +213,11 @@ struct dack_info {
 
 /* get current timestamp in ms */
 static inline uint32_t
-tcp_get_tms(uint32_t mshift)
+tcp_get_tms(uint32_t mshift, int32_t offset)
 {
 	uint64_t ts;
 	ts = rte_get_tsc_cycles() >> mshift;
+	ts -= offset;
 	return ts;
 }
 

--- a/lib/libtle_l4p/tcp_stream.c
+++ b/lib/libtle_l4p/tcp_stream.c
@@ -188,7 +188,7 @@ alloc_timers(const struct tle_ctx *ctx)
 	twprm.max_timer = ctx->prm.max_streams;
 	twprm.socket_id = ctx->prm.socket_id;
 
-	twl = tle_timer_create(&twprm, tcp_get_tms(ctx->cycles_ms_shift));
+	twl = tle_timer_create(&twprm, tcp_get_tms(ctx->cycles_ms_shift, 0));
 	if (twl == NULL)
 		TCP_LOG(ERR, "alloc_timers(ctx=%p) failed with error=%d\n",
 			ctx, rte_errno);
@@ -381,6 +381,8 @@ tcp_stream_fill_cfg(struct tle_tcp_stream *s, const struct tle_ctx_param *cprm,
 				cprm->icw;
 	s->tcb.snd.rto_tw = (cprm->timewait == TLE_TCP_TIMEWAIT_DEFAULT) ?
 				TCP_RTO_2MSL : cprm->timewait;
+
+	s->ts_offset = 0;
 
 	s->s.udata = scfg->udata;
 }

--- a/lib/libtle_l4p/tcp_stream.h
+++ b/lib/libtle_l4p/tcp_stream.h
@@ -113,6 +113,8 @@ struct tle_tcp_stream {
 		struct tle_dest dst;
 	} tx __rte_cache_aligned;
 
+	int32_t ts_offset; /* TS.VAL offset from TSC calculated */
+
 } __rte_cache_aligned;
 
 #define TCP_STREAM(p)	\


### PR DESCRIPTION
Signed-off-by: Ben Magistro <koncept1@gmail.com>
Change-Id: Icb65a2a2bf2f0b647fb8927c9c4adb88b9eb2131